### PR TITLE
Calls `compileFiles` after 'build/' is cleaned

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,22 +161,21 @@
 		 */
 		removeBuild(function () {
 			buildAssets();
-		});
 
-		/**
-		 * get all hbs files in the views directory and pass to compileFiles(), run finalizeBuild on completion.
-		 * @param  {String} glob string
-		 * @param  {Object} glob settings
-		 * @param  {Function} glob callback
-		 */
+			/**
+			 * get all hbs files in the views directory and pass to compileFiles(), run finalizeBuild on completion.
+			 * @param  {String} glob string
+			 * @param  {Object} glob settings
+			 * @param  {Function} glob callback
+			 */
 
-		globby('./site-sections/**/views/*.hbs', {
-			ignore: ignoreArr
-		}).then(data => {
-			// compile files based on views directory, close server when complete.
-			compileFiles(data, function () {
-				finalizeBuild();
+			globby('./site-sections/**/views/*.hbs', {
+				ignore: ignoreArr
+			}).then(data => {
+				// compile files based on views directory, close server when complete.
+				compileFiles(data, function () {
+					finalizeBuild();
+				});
 			});
 		});
-
 	})();


### PR DESCRIPTION
This prevents race-condition scenarios where we've already written HTML
files to 'build/' but `removeBuild` hasn't finished running yet, meaning that
when `removeBuild` _does_ run, it'll delete the HTML file(s) that have already
been created.

Don't know why this recently started cropping up, but I was seeing it every
once in a while for 'root/index.html'.